### PR TITLE
Update RingView.java

### DIFF
--- a/ring/src/main/java/org/ithot/android/view/RingView.java
+++ b/ring/src/main/java/org/ithot/android/view/RingView.java
@@ -141,9 +141,8 @@ public class RingView extends View {
     }
 
     private void supply(MotionEvent event) {
-        float sw = foregroundPaint.getStrokeWidth();
-        int width = (int) (ovalRectF.width() + sw);
-        int height = (int) (ovalRectF.height() + sw);
+        int width = getMeasuredWidth();
+        int height = getMeasuredHeight();
         int halfW = width / 2;
         int halfH = height / 2;
         int centerX = (int) ovalRectF.centerX();
@@ -170,6 +169,12 @@ public class RingView extends View {
             }
         }
         int real = startAngle - DEFAULT_START_ANGLE;
+        boolean angleCross = real + sweepAngle > 360;
+        if (angleCross) {
+            if (angle > (real + sweepAngle) % 360 && angle < real)
+                return;
+            else if( angle < real)
+                angle +=360;
         if (angle > real + sweepAngle || angle < real) {
             return;
         }


### PR DESCRIPTION
Was almost right last time, this is accurate on the exact center.  I caught it when I have a ring that ends on a 90/180/270/360 boundary.  I couldn't get it to read 0 ||100 % of the value.
Second if you have a ring that starts on one side of 360 and ends on the other as int startAngle = 300 and sweepAngle = 120 (crosses the 360 boundary) it wouldn't work.  So I added the angleCross boolean to fix this issue